### PR TITLE
Fix: django 2.0 compatibility

### DIFF
--- a/msgpackfield/msgpackfield.py
+++ b/msgpackfield/msgpackfield.py
@@ -72,7 +72,7 @@ class JsonTextWidget ( Textarea ) :
 
 
 ############################################################################
-#   @brief  A Django model field for storing data in MsgPack format in the 
+#   @brief  A Django model field for storing data in MsgPack format in the
 #   database.
 #
 #   This model field does automatic serialization/deserialization of data
@@ -131,7 +131,10 @@ class MsgPackField ( models.Field ) :
     ######################################################################
     ######################################################################
     def value_to_string ( self, obj ) :
-        value = self._get_val_from_obj( obj )
+        if hasattr(self, '_get_val_from_obj'):
+            value = self._get_val_from_obj(obj)
+        else:
+            value = super( MsgPackField, self ).value_from_object(obj)
         return json.dumps( value, indent="\t", separators=(', ', ': ') )
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open('README.md').readlines()
 
 setup(
     name='django-msgpackfield',
-    version='0.14',
+    version='0.15',
     packages=find_packages(),
     include_package_data=True,
     license='MIT License',
@@ -21,7 +21,7 @@ setup(
     ),
     classifiers=[
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 2.0',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',


### PR DESCRIPTION
See [similar fix in other library](https://github.com/pennersr/django-allauth/issues/1865).

Brief: `Field._get_val_from_obj` method has been deprecated and is removed from Django 2.0. But there's recommended way to use `Field.value_from_object()` instead.

This fix is checking if `_get_val_from_obj` is defined on the field instance. This is acceptable for my use case, because the msgpack field's serialization method is only used (hence broken) in our unit tests.

Thanks for reviewing!